### PR TITLE
Two CI Improvements (GitVersioniser Preview & No More Duplicate Jobs) #patch

### DIFF
--- a/.github/workflows/GitVersioniser-Preview.yml
+++ b/.github/workflows/GitVersioniser-Preview.yml
@@ -1,0 +1,69 @@
+name: GitVersioniser (Preview Only)
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  Preview_Next_Version:
+    runs-on: ubuntu-latest
+    name: Repository Versioning via GitVersioniser
+    steps:
+      - name: Repository Checkout
+        uses: actions/checkout@v3
+        with:
+          path: target_repository
+          fetch-depth: 0
+      - name: Running GitVersioniser
+        id: gitversioniser
+        uses: luzkan/GitVersioniser@main
+        with:
+          # ===========================
+          #        Credentials
+          # ---------------------------
+          # Versioniser Git Credentials
+          # ----
+          versioniser_username: "GitVersioniser"
+          versioniser_email: "luzkan.gitversioniser@github.com"
+
+          # ===========================
+          #          Patterns
+          # ---------------------------
+          # Increment Tags
+          # ----
+          commit_pattern_increment_tags: "HashtagExplicit"
+          # ---------------------------
+          # Change Tags
+          # ----
+          commit_pattern_change_tags: "All"
+  
+          # ===========================
+          #          Routines
+          # ---------------------------
+          # Versioning
+          # ----
+          routine_version: "VersionTagInCommitsTillLastGitVersioniserCommit"
+          # ---------------------------
+          # Contributing
+          # ----
+          routine_should_contribute: "Never"  # this disables the GitVersioniser, but allows to check the result before merging
+          routine_commiting: "Null"
+          routine_tagging: "Never"
+          # ---------------------------
+          # Commit Message
+          # ----
+          routine_commit_message_describe_changes: "WithEmoji"
+          routine_commit_message_format_version_tag: "FullButOnlyDigits"
+          routine_commit_message_place_version_tag: "Prefix"
+          routine_commit_message_summarize_changes: "WithEmojiCounted"
+          # ---------------------------
+          # Tagging
+          # ----
+          routine_prefix_tag_with_v: "Never"
+          # ---------------------------
+          # Changelog Handling
+          # -----
+          routine_changelog: "CommitChangeTags"
+          # ---------------------------
+          # File Versioning
+          # ----
+          routine_file_updater: "VersioniseFiles"
+          versioned_files: "package.json"

--- a/.github/workflows/Linters.yml
+++ b/.github/workflows/Linters.yml
@@ -5,8 +5,6 @@ name: Linters
 
 on:
   push:
-  pull_request:
-    branches: [master, main]
 
 env: # Comment env block if you do not want to apply fixes
   APPLY_FIXES: none # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,8 +20,6 @@ All notable changes to this project will be documented in this file.
 
 - Fowler name in Alternative Classes with Different Interfaces #patch
 
-
-
 ## [[`1.0.12`]] - 2022-08-21
 
 ### Other
@@ -35,8 +33,6 @@ All notable changes to this project will be documented in this file.
 ### Typo
 
 - fix(binary-operator-in-name.md): correct typo #patch
-
-
 
 ## [[`1.0.10`]] - 2022-08-15
 


### PR DESCRIPTION
Allows to check the [GitVersioniser](https://github.com/Luzkan/GitVersioniser) versioning result before merging to [main](https://github.com/Luzkan/smells/tree/main).