### PR TITLE
Fixing error in shotgun surgery comparison to Solution Sprawl

### DIFF
--- a/content/smells/shotgun-surgery.md
+++ b/content/smells/shotgun-surgery.md
@@ -74,7 +74,7 @@ history:
 
 Similar to [Divergent Change](./divergent-change.md), but with a broader spectrum, the smell symptom of the _Shotgun Surgery_ code is detected by the unnecessary requirement of changing multiple different classes to introduce a single modification. Things like that can happen with the failure to use the correct design pattern for the given system. This expansion of functionality can lead to an easy miss (and thus introduce a bug) if these small changes are all over the place and they are hard to find. Most likely, [too many classes](./oddball-solution.md) solve a simple problem.
 
-Joshua Kerievsky noted this smell as _Solution Sprawl_ [[1](#sources)]. Monteiro stated that the tiny difference between these two comes from how they are sensed. In the [Divergent Change](./divergent-change.md), one becomes aware of the smell while making the changes, and in the _Solution Sprawl_, one is aware by observing the issue. [[2](#sources)]
+Joshua Kerievsky noted this smell as _Solution Sprawl_ [[1](#sources)]. Monteiro stated that the tiny difference between these two comes from how they are sensed. In the _Shotgun Surgery_, one becomes aware of the smell while making the changes, and in the _Solution Sprawl_, one is aware by observing the issue. [[2](#sources)]
 
 ### Causation
 


### PR DESCRIPTION
Monteiro states in the _OO Smells in the Light of AO_ section that:

"The difference between the two smells is the way they
are sensed – “we become aware of Solution Sprawl by observing
it, while we detect Shogun Surgery by doing it”. "

That's why I think, instead of 

"In the Divergent Change, one becomes aware of the smell while making the changes, and in the Solution Sprawl, one is aware by observing the issue." 

it should say 

"In the Shotgun Surgery, one becomes aware of the smell while making the changes, and in the Solution Sprawl, one is aware by observing the issue."